### PR TITLE
add precise32 config.vm.box_url

### DIFF
--- a/vagrant/gauntlt/Vagrantfile
+++ b/vagrant/gauntlt/Vagrantfile
@@ -15,7 +15,7 @@ Vagrant::Config.run do |config|
 
   # The url from where the 'config.vm.box' box will be fetched if it
   # doesn't already exist on the user's system.
-  # config.vm.box_url = "http://domain.com/path/to/above.box"
+  config.vm.box_url = "http://files.vagrantup.com/precise32.box"
 
   # Boot with a GUI so you can see the screen. (Default is headless)
   # config.vm.boot_mode = :gui


### PR DESCRIPTION
for people who don't use Vagrant Getting Started anymore and don't have @mitchellh's precise32 box (really any box named "precise32")

_note: it might be a good idea to change the box name, and have config.vm.box_url set to prevent people making their own boxes named "precise32" and breaking the gauntlt quickstart, although those edge cases are probably few and far between._
