### PR TITLE
Update default.rb to force arachni 1.0.6

### DIFF
--- a/vagrant/gauntlt/site-cookbooks/vagrant_main/recipes/default.rb
+++ b/vagrant/gauntlt/site-cookbooks/vagrant_main/recipes/default.rb
@@ -30,7 +30,8 @@ end
 end
 
 execute "install gems" do
-  command "/usr/bin/ruby -S gem install gauntlt bundler arachni"
+  command "/usr/bin/ruby -S gem install arachni -v 1.0.6"
+  command "/usr/bin/ruby -S gem install gauntlt bundler"
 end
 
 # install sslyze


### PR DESCRIPTION
closes gauntlt/gauntlt-starter-kit#8

arachni 1.1 requires Ruby >= 2.0.0, this pins the gauntlt-starter-kit to arachni 1.0.6 for ruby 1.9.3
